### PR TITLE
fix: action errors when schedule is empty and no triggers are defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@reteps/github-action-scheduler",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Schedule a GitHub Actions run from a TypeScript script",
   "main": "dist/index.js",
-  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",

--- a/src/__tests__/empty.test.ts
+++ b/src/__tests__/empty.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { generateWorkflow } from '../index';
+
+describe('empty', () => {
+  it('if no jobs are passed, no scheduled cron jobs', async () => {
+    const result = await generateWorkflow([], false);
+    const correct = {
+      name: "Scheduled Jobs",
+      on: {
+        workflow_dispatch: {},
+      },
+      jobs: {},
+    };
+    expect(result).toEqual(correct);
+  });
+});

--- a/workflow.yml
+++ b/workflow.yml
@@ -2,9 +2,10 @@ name: Scheduled Jobs
 'on':
   schedule:
     - cron: 0 18 31 12 4
+  workflow_dispatch: {}
 jobs:
-  Deploy-(fallctf.com):
-    name: Deploy (fallctf.com)
+  Deploy-fallctfcom-at-2021-01-01T000000000Z:
+    name: Deploy (fallctf.com) at 2021-01-01T00:00:00.000Z
     if: github.event.schedule == '0 18 31 12 4'
     permissions:
       contents: read


### PR DESCRIPTION
- fix: `schedule` must always contain at least one cron entry (typed function signature is insufficient for runtimes), so now it is removed if there are no cron jobs
- `on` requires at least one trigger, so if `schedule` is removed, then the `workflow_dispatch` trigger now acts as a fallback
- fix: no longer `type: module` so tests work again
- lift workflow generation code to a separate function so that it can be used in tests
- add empty test case